### PR TITLE
Update linkfinder.py

### DIFF
--- a/linkfinder.py
+++ b/linkfinder.py
@@ -129,7 +129,8 @@ def send_request(url):
     Send requests with Requests
     '''
     q = Request(url)
-    sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    # Support websites that force TLSv1.2
+    sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
 
     q.add_header('User-Agent', 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
         AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36')


### PR DESCRIPTION
changed line

```python
sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
```

with
```python
sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
```

to support tlsv1.2 which some websites force and would result in the error
```bash
Error: invalid input defined or SSL error: <urlopen error [SSL: TLSV1_ALERT_PROTOCOL_VERSION] tlsv1 alert protocol version (_ssl.c:645)>
```