### PR TITLE
Refactoring command into main block

### DIFF
--- a/linkfinder.py
+++ b/linkfinder.py
@@ -132,7 +132,7 @@ def send_request(url):
 
     return data.decode('utf-8', 'replace')
 
-def parser_file(content, regex):
+def parser_file(content, regex, more_regex=None):
     '''
     Parse Input
     '''
@@ -153,8 +153,8 @@ def parser_file(content, regex):
         # Remove other capture groups from regex results
         group = list(filter(None, item))
 
-        if args.regex:
-            if re.search(args.regex, group[1]):
+        if more_regex:
+            if re.search(more_regex, group[1]):
                 filtered_items.append(group)
         else:
             filtered_items.append(group)
@@ -257,7 +257,7 @@ if __name__ == "__main__":
             file = url['js']
             url = url['url']
 
-        endpoints = parser_file(file, regex)
+        endpoints = parser_file(file, regex, args.regex)
         if args.domain:
             for endpoint in endpoints:
                 endpoint = cgi.escape(endpoint[1]).encode('ascii', 'ignore').decode('utf8')
@@ -268,7 +268,7 @@ if __name__ == "__main__":
                 print("")
                 try:
                     file = send_request(endpoint)
-                    new_endpoints = parser_file(file, regex)
+                    new_endpoints = parser_file(file, regex, args.regex)
                     if args.output == 'cli':
                         cli_output(new_endpoints)
                     else:

--- a/linkfinder.py
+++ b/linkfinder.py
@@ -138,12 +138,11 @@ def parser_file(content, regex):
     '''
     
     # Beautify
-    if args.output != 'cli':
-        if len(content) > 1000000:
-            content = content.replace(";",";\r\n").replace(",",",\r\n")
-        else:
-            content = jsbeautifier.beautify(content)
-    
+    if len(content) > 1000000:
+        content = content.replace(";",";\r\n").replace(",",",\r\n")
+    else:
+        content = jsbeautifier.beautify(content)
+
     items = re.findall(regex, content)
     items = list(set(items))
         

--- a/linkfinder.py
+++ b/linkfinder.py
@@ -30,7 +30,7 @@ regex_str = r"""
 
   (?:"|')                               # Start newline delimiter
 
-  (?:
+  (?P<link>
     ((?:[a-zA-Z]{1,10}://|//)           # Match a scheme [a-Z]*1-10 or //
     [^"'/]{1,}\.                        # Match a domainname (any character + dot)
     [a-zA-Z]{2,}[^"']{0,})              # The domainextension and/or path
@@ -137,8 +137,13 @@ def send_request(url):
 def parser_file(content, regex_str, mode=1, more_regex=None):
     '''
     Parse Input
-    mode 0: Without context
-    mode 1: With context
+    content:    string of content to be searched
+    regex_str:  string of regex (must wrap regex group with ?P<link>)
+    mode:       mode of parsing. Set 1 to include surrounding contexts in the result
+    more_regex: string of regex to filter the result
+
+    Return the list of ["link": link, "context": context]
+    The context is optional if mode=1 is provided.
     '''
     global context_delimiter_str
 
@@ -148,26 +153,24 @@ def parser_file(content, regex_str, mode=1, more_regex=None):
             content = content.replace(";",";\r\n").replace(",",",\r\n")
         else:
             content = jsbeautifier.beautify(content)
-        # Wrap regex with group of newline
-        regex = re.compile("(" + context_delimiter_str + regex_str + context_delimiter_str + ")", re.VERBOSE)
+        # Wrap regex group with newline. This will return "link" and "context"
+        regex = re.compile("(?P<context>" + context_delimiter_str + regex_str + context_delimiter_str + ")", re.VERBOSE)
     else:
         regex = re.compile(regex_str, re.VERBOSE)
 
-    items = re.findall(regex, content)
-    items = list(set(items))
+    items = re.finditer(regex, content)
+    # Remove duplicate
+    items = {item['link']:item for item in items}.values()
 
     # Match Regex
     filtered_items = []
-
     for item in items:
         # Remove other capture groups from regex results
-        group = list(filter(None, item))
-
         if more_regex:
-            if re.search(more_regex, group[1]):
-                filtered_items.append(group)
+            if re.search(more_regex, item["link"]):
+                filtered_items.append(item)
         else:
-            filtered_items.append(group)
+            filtered_items.append(item)
 
     return filtered_items
 
@@ -176,7 +179,7 @@ def cli_output(endpoints):
     Output to CLI
     '''
     for endpoint in endpoints:
-        print(cgi.escape(endpoint[0]).encode(
+        print(cgi.escape(endpoint["link"]).encode(
             'ascii', 'ignore').decode('utf8'))
 
 def html_save(html):
@@ -274,7 +277,7 @@ if __name__ == "__main__":
         endpoints = parser_file(file, regex_str, mode, args.regex)
         if args.domain:
             for endpoint in endpoints:
-                endpoint = cgi.escape(endpoint[1]).encode('ascii', 'ignore').decode('utf8')
+                endpoint = cgi.escape(endpoint["link"]).encode('ascii', 'ignore').decode('utf8')
                 endpoint = check_url(endpoint)
                 if endpoint is False:
                     continue
@@ -291,18 +294,18 @@ if __name__ == "__main__":
                         ''' % (cgi.escape(endpoint), cgi.escape(endpoint))
 
                         for endpoint2 in new_endpoints:
-                            url = cgi.escape(endpoint2[1])
+                            url = cgi.escape(endpoint2["link"])
                             string = "<div><a href='%s' class='text'>%s" % (
                                 cgi.escape(url),
                                 cgi.escape(url)
                             )
                             string2 = "</a><div class='container'>%s</div></div>" % cgi.escape(
-                                endpoint2[0]
+                                endpoint2["context"]
                             )
                             string2 = string2.replace(
-                                cgi.escape(endpoint2[1]),
+                                cgi.escape(endpoint2["link"]),
                                 "<span style='background-color:yellow'>%s</span>" %
-                                cgi.escape(endpoint2[1])
+                                cgi.escape(endpoint2["link"])
                             )
                             html += string + string2
                 except Exception as e:
@@ -317,18 +320,18 @@ if __name__ == "__main__":
                 ''' % (cgi.escape(url), cgi.escape(url))
 
             for endpoint in endpoints:
-                url = cgi.escape(endpoint[1])
+                url = cgi.escape(endpoint["link"])
                 string = "<div><a href='%s' class='text'>%s" % (
                     cgi.escape(url),
                     cgi.escape(url)
                 )
                 string2 = "</a><div class='container'>%s</div></div>" % cgi.escape(
-                    endpoint[0]
+                    endpoint["context"]
                 )
                 string2 = string2.replace(
-                    cgi.escape(endpoint[1]),
+                    cgi.escape(endpoint["link"]),
                     "<span style='background-color:yellow'>%s</span>" %
-                    cgi.escape(endpoint[1])
+                    cgi.escape(endpoint["link"])
                 )
 
                 html += string + string2

--- a/linkfinder.py
+++ b/linkfinder.py
@@ -25,44 +25,10 @@ try:
 except ImportError:
     from urllib2 import Request, urlopen
 
-# Parse command line
-parser = argparse.ArgumentParser()
-parser.add_argument("-d", "--domain",
-                    help="Input a domain to recursively parse all javascript located in a page",
-                    action="store_true")
-parser.add_argument("-i", "--input",
-                    help="Input a: URL, file or folder. \
-                    For folders a wildcard can be used (e.g. '/*.js').",
-                    required="True", action="store")
-parser.add_argument("-o", "--output",
-                    help="Where to save the file, \
-                    including file name. Default: output.html",
-                    action="store", default="output.html")
-parser.add_argument("-r", "--regex",
-                    help="RegEx for filtering purposes \
-                    against found endpoint (e.g. ^/api/)",
-                    action="store")
-parser.add_argument("-b", "--burp",
-                    help="",
-                    action="store_true")
-parser.add_argument("-c", "--cookies",
-                    help="Add cookies for authenticated JS files",
-                    action="store", default="")
-args = parser.parse_args()
-
-if args.input[-1:] == "/":
-    args.input = args.input[:-1]
-
-# Newlines in regex? Important for CLI output without jsbeautifier
-if args.output != 'cli':
-    addition = ("[^\n]*","[^\n]*")
-else:
-    addition = ("","")
-
 # Regex used
 regex = re.compile(r"""
 
-  (%s(?:"|')                            # Start newline delimiter
+  ((?:"|')                            # Start newline delimiter
 
   (?:
     ((?:[a-zA-Z]{1,10}://|//)           # Match a scheme [a-Z]*1-10 or //
@@ -72,7 +38,7 @@ regex = re.compile(r"""
     |
 
     ((?:/|\.\./|\./)                    # Start with /,../,./
-    [^"'><,;| *()(%%$^/\\\[\]]          # Next character can't be... 
+    [^"'><,;| *()(%%$^/\\\[\]]          # Next character can't be...
     [^"'><,;|()]{1,})                   # Rest of the characters can't be
 
     |
@@ -86,12 +52,12 @@ regex = re.compile(r"""
     ([a-zA-Z0-9_\-]{1,}                 # filename
     \.(?:php|asp|aspx|jsp|json)         # . + extension
     (?:\?[^"|']{0,}|))                  # ? mark with parameters
- 
-  )             
-  
-  (?:"|')%s)                            # End newline delimiter
 
-""" % addition, re.VERBOSE)
+  )
+
+  (?:"|'))                            # End newline delimiter
+
+""", re.VERBOSE)
 
 def parser_error(errmsg):
     '''
@@ -166,7 +132,7 @@ def send_request(url):
 
     return data.decode('utf-8', 'replace')
 
-def parser_file(content):
+def parser_file(content, regex):
     '''
     Parse Input
     '''
@@ -202,7 +168,7 @@ def cli_output(endpoints):
     '''
     for endpoint in endpoints:
         print(cgi.escape(endpoint[1]).encode(
-            'ascii', 'ignore').decode('utf8')) 
+            'ascii', 'ignore').decode('utf8'))
 
 def html_save(html):
     '''
@@ -244,85 +210,115 @@ def check_url(url):
                 url = args.input + url
             else:
                 url = args.input + "/" + url
-        return url            
+        return url
     else:
         return False
-# Convert input to URLs or JS files
-urls = parser_input(args.input)  
 
-# Convert URLs to JS
-html = ''
-for url in urls:
-    if not args.burp:
-        try:
-            file = send_request(url)
-        except Exception as e:
-            parser_error("invalid input defined or SSL error: %s" % e)
-    else:
-        file = url['js']
-        url = url['url']
+if __name__ == "__main__":
+    # Parse command line
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d", "--domain",
+                        help="Input a domain to recursively parse all javascript located in a page",
+                        action="store_true")
+    parser.add_argument("-i", "--input",
+                        help="Input a: URL, file or folder. \
+                        For folders a wildcard can be used (e.g. '/*.js').",
+                        required="True", action="store")
+    parser.add_argument("-o", "--output",
+                        help="Where to save the file, \
+                        including file name. Default: output.html",
+                        action="store", default="output.html")
+    parser.add_argument("-r", "--regex",
+                        help="RegEx for filtering purposes \
+                        against found endpoint (e.g. ^/api/)",
+                        action="store")
+    parser.add_argument("-b", "--burp",
+                        help="",
+                        action="store_true")
+    parser.add_argument("-c", "--cookies",
+                        help="Add cookies for authenticated JS files",
+                        action="store", default="")
+    args = parser.parse_args()
 
-    endpoints = parser_file(file)
-    if args.domain:
-        for endpoint in endpoints:
-            endpoint = cgi.escape(endpoint[1]).encode('ascii', 'ignore').decode('utf8')
-            endpoint = check_url(endpoint)
-            if endpoint is False:
-                continue
-            print("Running against: " + endpoint)
-            print("")
+    if args.input[-1:] == "/":
+        args.input = args.input[:-1]
+
+    # Convert input to URLs or JS files
+    urls = parser_input(args.input)
+
+    # Convert URLs to JS
+    html = ''
+    for url in urls:
+        if not args.burp:
             try:
-                file = send_request(endpoint)
-                new_endpoints = parser_file(file)
-                if args.output == 'cli':
-                    cli_output(new_endpoints)
-                else:
-                    html += '''
-                    <h1>File: <a href="%s" target="_blank" rel="nofollow noopener noreferrer">%s</a></h1>
-                    ''' % (cgi.escape(endpoint), cgi.escape(endpoint))
-
-                    for endpoint2 in new_endpoints:
-                        url = cgi.escape(endpoint2[1])
-                        string = "<div><a href='%s' class='text'>%s" % (
-                            cgi.escape(url),
-                            cgi.escape(url)
-                        )
-                        string2 = "</a><div class='container'>%s</div></div>" % cgi.escape(
-                            endpoint2[0]
-                        )
-                        string2 = string2.replace(
-                            cgi.escape(endpoint2[1]),
-                            "<span style='background-color:yellow'>%s</span>" %
-                            cgi.escape(endpoint2[1])
-                        )
-                        html += string + string2
+                file = send_request(url)
             except Exception as e:
-                print("Invalid input defined or SSL error for: " + endpoint)
-                continue
-    
-    if args.output == 'cli':
-        cli_output(endpoints)
-    else:
-        html += '''
-            <h1>File: <a href="%s" target="_blank" rel="nofollow noopener noreferrer">%s</a></h1>
-            ''' % (cgi.escape(url), cgi.escape(url))
+                parser_error("invalid input defined or SSL error: %s" % e)
+        else:
+            file = url['js']
+            url = url['url']
 
-        for endpoint in endpoints:
-            url = cgi.escape(endpoint[1])
-            string = "<div><a href='%s' class='text'>%s" % (
-                cgi.escape(url),
-                cgi.escape(url)
-            )
-            string2 = "</a><div class='container'>%s</div></div>" % cgi.escape(
-                endpoint[0]
-            )
-            string2 = string2.replace(
-                cgi.escape(endpoint[1]),
-                "<span style='background-color:yellow'>%s</span>" %
-                cgi.escape(endpoint[1])
-            )
+        endpoints = parser_file(file, regex)
+        if args.domain:
+            for endpoint in endpoints:
+                endpoint = cgi.escape(endpoint[1]).encode('ascii', 'ignore').decode('utf8')
+                endpoint = check_url(endpoint)
+                if endpoint is False:
+                    continue
+                print("Running against: " + endpoint)
+                print("")
+                try:
+                    file = send_request(endpoint)
+                    new_endpoints = parser_file(file, regex)
+                    if args.output == 'cli':
+                        cli_output(new_endpoints)
+                    else:
+                        html += '''
+                        <h1>File: <a href="%s" target="_blank" rel="nofollow noopener noreferrer">%s</a></h1>
+                        ''' % (cgi.escape(endpoint), cgi.escape(endpoint))
 
-            html += string + string2
+                        for endpoint2 in new_endpoints:
+                            url = cgi.escape(endpoint2[1])
+                            string = "<div><a href='%s' class='text'>%s" % (
+                                cgi.escape(url),
+                                cgi.escape(url)
+                            )
+                            string2 = "</a><div class='container'>%s</div></div>" % cgi.escape(
+                                endpoint2[0]
+                            )
+                            string2 = string2.replace(
+                                cgi.escape(endpoint2[1]),
+                                "<span style='background-color:yellow'>%s</span>" %
+                                cgi.escape(endpoint2[1])
+                            )
+                            html += string + string2
+                except Exception as e:
+                    print("Invalid input defined or SSL error for: " + endpoint)
+                    continue
 
-if args.output != 'cli':
-    html_save(html)
+        if args.output == 'cli':
+            cli_output(endpoints)
+        else:
+            html += '''
+                <h1>File: <a href="%s" target="_blank" rel="nofollow noopener noreferrer">%s</a></h1>
+                ''' % (cgi.escape(url), cgi.escape(url))
+
+            for endpoint in endpoints:
+                url = cgi.escape(endpoint[1])
+                string = "<div><a href='%s' class='text'>%s" % (
+                    cgi.escape(url),
+                    cgi.escape(url)
+                )
+                string2 = "</a><div class='container'>%s</div></div>" % cgi.escape(
+                    endpoint[0]
+                )
+                string2 = string2.replace(
+                    cgi.escape(endpoint[1]),
+                    "<span style='background-color:yellow'>%s</span>" %
+                    cgi.escape(endpoint[1])
+                )
+
+                html += string + string2
+
+    if args.output != 'cli':
+        html_save(html)

--- a/test_parser.py
+++ b/test_parser.py
@@ -9,7 +9,7 @@ def get_parse_cli(str):
     endpoints = parser_file(str, regex_str, mode=0)
     ret = []
     for endpoint in endpoints:
-        ret.append(endpoint[0])
+        ret.append(endpoint["link"])
     return ret
 
 def test_parser_cli():

--- a/test_parser.py
+++ b/test_parser.py
@@ -2,39 +2,39 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from linkfinder import regex, parser_file
+from linkfinder import regex_str, parser_file
 
 # Imitate cli_output function
-def get_parse(str):
-    endpoints = parser_file(str, regex)
+def get_parse_cli(str):
+    endpoints = parser_file(str, regex_str, mode=0)
     ret = []
     for endpoint in endpoints:
-        ret.append(endpoint[1])
+        ret.append(endpoint[0])
     return ret
 
-def test_parser():
-    assert get_parse("\"http://example.com\"") == ["http://example.com"]
-    assert get_parse("\"smb://example.com\"") == ["smb://example.com"]
-    assert get_parse("\"https://www.example.co.us\"") == ["https://www.example.co.us"]
+def test_parser_cli():
+    assert get_parse_cli("\"http://example.com\"") == ["http://example.com"]
+    assert get_parse_cli("\"smb://example.com\"") == ["smb://example.com"]
+    assert get_parse_cli("\"https://www.example.co.us\"") == ["https://www.example.co.us"]
 
-    assert get_parse("\"/path/to/file\"") == ["/path/to/file"]
-    assert get_parse("\"../path/to/file\"") == ["../path/to/file"]
-    assert get_parse("\"./path/to/file\"") == ["./path/to/file"]
-    assert get_parse("\"/wrong/file/test<>b\"") == []
+    assert get_parse_cli("\"/path/to/file\"") == ["/path/to/file"]
+    assert get_parse_cli("\"../path/to/file\"") == ["../path/to/file"]
+    assert get_parse_cli("\"./path/to/file\"") == ["./path/to/file"]
+    assert get_parse_cli("\"/wrong/file/test<>b\"") == []
 
-    assert get_parse("\"/api/create.php\"") == ["/api/create.php"]
-    assert get_parse("\"/api/create.php?user=test\"") == ["/api/create.php?user=test"]
-    assert get_parse("\"/api/create.php?user=test&pass=test\"") == ["/api/create.php?user=test&pass=test"]
-    assert get_parse("\"/api/create.php?user=test#home\"") == ["/api/create.php?user=test#home"]
+    assert get_parse_cli("\"/api/create.php\"") == ["/api/create.php"]
+    assert get_parse_cli("\"/api/create.php?user=test\"") == ["/api/create.php?user=test"]
+    assert get_parse_cli("\"/api/create.php?user=test&pass=test\"") == ["/api/create.php?user=test&pass=test"]
+    assert get_parse_cli("\"/api/create.php?user=test#home\"") == ["/api/create.php?user=test#home"]
 
-    assert get_parse("\"/path/to/file\"") == ["/path/to/file"]
-    assert get_parse("\"../path/to/file\"") == ["../path/to/file"]
-    assert get_parse("\"./path/to/file\"") == ["./path/to/file"]
-    assert get_parse("\"/wrong/file/test<>b\"") == []
+    assert get_parse_cli("\"/path/to/file\"") == ["/path/to/file"]
+    assert get_parse_cli("\"../path/to/file\"") == ["../path/to/file"]
+    assert get_parse_cli("\"./path/to/file\"") == ["./path/to/file"]
+    assert get_parse_cli("\"/wrong/file/test<>b\"") == []
 
-    assert get_parse("\"test_1.json\"") == ["test_1.json"]
-    assert get_parse("\"test2.aspx?arg1=tmp1+tmp2&arg2=tmp3\"") == ["test2.aspx?arg1=tmp1+tmp2&arg2=tmp3"]
+    assert get_parse_cli("\"test_1.json\"") == ["test_1.json"]
+    assert get_parse_cli("\"test2.aspx?arg1=tmp1+tmp2&arg2=tmp3\"") == ["test2.aspx?arg1=tmp1+tmp2&arg2=tmp3"]
 
 
-def test_parser_multi():
-    assert set(get_parse("href=\"http://example.com\";href=\"/api/create.php\"")) == set(["http://example.com", "/api/create.php"])
+def test_parser_cli_multi():
+    assert set(get_parse_cli("href=\"http://example.com\";href=\"/api/create.php\"")) == set(["http://example.com", "/api/create.php"])

--- a/test_parser.py
+++ b/test_parser.py
@@ -35,6 +35,12 @@ def test_parser_cli():
     assert get_parse_cli("\"test_1.json\"") == ["test_1.json"]
     assert get_parse_cli("\"test2.aspx?arg1=tmp1+tmp2&arg2=tmp3\"") == ["test2.aspx?arg1=tmp1+tmp2&arg2=tmp3"]
 
-
 def test_parser_cli_multi():
     assert set(get_parse_cli("href=\"http://example.com\";href=\"/api/create.php\"")) == set(["http://example.com", "/api/create.php"])
+
+def test_parser_unique():
+    '''
+    Should return only unique link
+    '''
+    assert get_parse_cli("href=\"http://example.com\";document.window.location=\"http://example.com\"") == ["http://example.com"]
+    assert set(get_parse_cli("href=\"http://example.com\";<img src=\"http://example.com\">;href=\"/api/create.php\"")) == set(["http://example.com", "/api/create.php"])


### PR DESCRIPTION
I decide to put the command line argument part into the __main__ block. This will allow other module to "import linkfinder" for further use.

I remove these lines because I notice that jsbeautifier is required for this module anyway.
```
# Newlines in regex? Important for CLI output without jsbeautifier
if args.output != 'cli':
    addition = ("[^\n]*","[^\n]*")
else:
    addition = ("","")
```

Also I don't really understand this part but I don't think output argument should alter input content so I remove this ``if args.output != 'cli':``. If it is necessary by any mean, I will add it back. 
```
def parser_file(content, regex, more_regex=None):
...
    # Beautify
    if args.output != 'cli': # <-- I don't know what this line does
        if len(content) > 1000000:
            content = content.replace(";",";\r\n").replace(",",",\r\n")
        else:
            content = jsbeautifier.beautify(content)
```

Also I try to remove global argument dependency. Accepting as function parameter will make the project easier to maintain and allow other code to import. I haven't done fixing this yet. I rush to fix parser_file function first so I could add unit-test into this project.

Any suggestion/change/opinion is appreciated.
Also since I did change a lot of lines, (even I have tested on my part, it's might not be covered), further test is also appreciated.