### PR TITLE
add basic-unit-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ Short Form    | Long Form     | Description
 
 ``python linkfinder.py -i 'Desktop/*.js' -r ^/api/ -o results.html``
 
+## Unit-test
+
+* Require pytest
+
+``pytest test_parser.py``
+
 ## Final remarks
 - This is the first time I publicly release a tool. Contributions are much appreciated!
 - LinkFinder is published under the [MIT License](https://github.com/GerbenJavado/LinkFinder/blob/master/LICENSE).

--- a/test_parser.py
+++ b/test_parser.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pytest
+from linkfinder import regex, parser_file
+
+# Imitate cli_output function
+def get_parse(str):
+    endpoints = parser_file(str, regex)
+    ret = []
+    for endpoint in endpoints:
+        ret.append(endpoint[1])
+    return ret
+
+def test_parser():
+    assert get_parse("\"http://example.com\"") == ["http://example.com"]
+    assert get_parse("\"smb://example.com\"") == ["smb://example.com"]
+    assert get_parse("\"https://www.example.co.us\"") == ["https://www.example.co.us"]
+
+    assert get_parse("\"/path/to/file\"") == ["/path/to/file"]
+    assert get_parse("\"../path/to/file\"") == ["../path/to/file"]
+    assert get_parse("\"./path/to/file\"") == ["./path/to/file"]
+    assert get_parse("\"/wrong/file/test<>b\"") == []
+
+    assert get_parse("\"/api/create.php\"") == ["/api/create.php"]
+    assert get_parse("\"/api/create.php?user=test\"") == ["/api/create.php?user=test"]
+    assert get_parse("\"/api/create.php?user=test&pass=test\"") == ["/api/create.php?user=test&pass=test"]
+    assert get_parse("\"/api/create.php?user=test#home\"") == ["/api/create.php?user=test#home"]
+
+    assert get_parse("\"/path/to/file\"") == ["/path/to/file"]
+    assert get_parse("\"../path/to/file\"") == ["../path/to/file"]
+    assert get_parse("\"./path/to/file\"") == ["./path/to/file"]
+    assert get_parse("\"/wrong/file/test<>b\"") == []
+
+    assert get_parse("\"test_1.json\"") == ["test_1.json"]
+    assert get_parse("\"test2.aspx?arg1=tmp1+tmp2&arg2=tmp3\"") == ["test2.aspx?arg1=tmp1+tmp2&arg2=tmp3"]
+
+
+def test_parser_multi():
+    assert set(get_parse("href=\"http://example.com\";href=\"/api/create.php\"")) == set(["http://example.com", "/api/create.php"])


### PR DESCRIPTION
It will be hard to improve the code (especially regex) without the unit-test to make sure that there is no regression/bug. I hope this unit-test will help improve the project and its search accuracy further.

Since this module uses `import linkfinder`, **it is necessary that current code properly manages main block**. I have done that in #43 . If that code contains any issue, someone else could fix it another way and still be able to merge this PR without any side-effect.

This test-case is provided as basic one. We could add more and more tests into it later.