### PR TITLE
Improve performance of context search

### DIFF
--- a/linkfinder.py
+++ b/linkfinder.py
@@ -137,9 +137,9 @@ def send_request(url):
 def getContext(list_matches, content, include_delimiter=0, context_delimiter_str="\n"):
     '''
     Parse Input
-    list_matches:   list of tuple [link, start_index, end_index]
-    content:        content to search the context
-    include_delimiter   also include delimiter in the context
+    list_matches:       list of tuple (link, start_index, end_index)
+    content:            content to search for the context
+    include_delimiter   Set 1 to include delimiter in context
     '''
     items = []
     for m in list_matches:
@@ -174,7 +174,7 @@ def parser_file(content, regex_str, mode=1, more_regex=None, no_dup=1):
     '''
     Parse Input
     content:    string of content to be searched
-    regex_str:  string of regex (Only 1 group should be matched)
+    regex_str:  string of regex (The link should be in the group(1))
     mode:       mode of parsing. Set 1 to include surrounding contexts in the result
     more_regex: string of regex to filter the result
     no_dup:     remove duplicated link (context is NOT counted)

--- a/linkfinder.py
+++ b/linkfinder.py
@@ -194,7 +194,13 @@ def parser_file(content, regex_str, mode=1, more_regex=None, no_dup=1):
         items = [{"link": m.group(1)} for m in re.finditer(regex, content)]
 
     if no_dup:
-        items = [dict(t) for t in {tuple(sorted(d.items())) for d in items}]
+        all_links = set()
+        no_dup_items = []
+        for item in items:
+            if item["link"] not in all_links:
+                all_links.add(item["link"])
+                no_dup_items.append(item)
+        items = no_dup_items
 
     # Match Regex
     filtered_items = []

--- a/linkfinder.py
+++ b/linkfinder.py
@@ -134,9 +134,13 @@ def send_request(url):
 
     return data.decode('utf-8', 'replace')
 
-def getContext(list_matches, content, include_delimiter=0):
-    global context_delimiter_str
-
+def getContext(list_matches, content, include_delimiter=0, context_delimiter_str="\n"):
+    '''
+    Parse Input
+    list_matches:   list of tuple [link, start_index, end_index]
+    content:        content to search the context
+    include_delimiter   also include delimiter in the context
+    '''
     items = []
     for m in list_matches:
         match_str = m[0]
@@ -178,6 +182,8 @@ def parser_file(content, regex_str, mode=1, more_regex=None, no_dup=1):
     Return the list of ["link": link, "context": context]
     The context is optional if mode=1 is provided.
     '''
+    global context_delimiter_str
+
     if mode == 1:
         # Beautify
         if len(content) > 1000000:
@@ -189,11 +195,12 @@ def parser_file(content, regex_str, mode=1, more_regex=None, no_dup=1):
 
     if mode == 1:
         all_matches = [(m.group(1), m.start(0), m.end(0)) for m in re.finditer(regex, content)]
-        items = getContext(all_matches, content)
+        items = getContext(all_matches, content, context_delimiter_str=context_delimiter_str)
     else:
         items = [{"link": m.group(1)} for m in re.finditer(regex, content)]
 
     if no_dup:
+        # Remove duplication
         all_links = set()
         no_dup_items = []
         for item in items:


### PR DESCRIPTION
# Issue
Searching link with context is too slow

# Cause and solution
- I think regex for searching context is ineffective. ([^\n]*) means matching everything (except newline) while it might not even match our link regex in the middle.
- I change it to offset search based on the link instead (We know cli only searches for link and is very fast)

# Result
- I think it's depends on the context too. I have gotten like x2-x4 better performance. On nu.nl seems to give x10. Performance can be varied on CPU/disk/OS so more test (both better/worse) is always appreciated.

New version
```
$ time (python linkfinder.py -i https://www.nu.nl/ -d)

real	0m37.334s
user	0m16.256s
sys	0m0.092s
```
Old version
```
$ time (python linkfinder.py -i https://www.nu.nl/ -d)

real	6m36.491s
user	5m58.722s
sys	0m0.083s
```

# More
- I also fixed random crash from python2 (I'm not sure how it happens, more like issue with python2 regex + ordering). Does not affect python3.
- I use this code to confirm that everything is ok during transit between old and new version (Note there will always be dupe from different URL when using -d mode)
```
import re

d = {}
regex = re.compile("<div><a href='([^'\n]*)' class='text'>")

f = open("new_today.html", "r")
w1 = open("tmp1", "w+")
content = f.read()
items = re.findall(regex, content)
for item in items:
    if item in d:
        print("Dupe %s" % (item))
    d[item] = 1
    w1.write(item + "\n")
        
f = open("old_today.html", "r")
w2 = open("tmp2", "w+")
content = f.read()
items = re.findall(regex, content)
for item in items:
    if item not in d:
        print("Miss from new %s" % (item))
    d[item] = 2
    w2.write(item + "\n")
    
for item in d:
    if d[item] == 1:
        print("Miss from old %s" % (item))
    
w1.close()
w2.close()
print("Done")
```

# Further action
- I would love any recommendation, test, feedback before we merge into main. I don't want anything to crash :P