### PR TITLE
Improve more extensions detect

### DIFF
--- a/linkfinder.py
+++ b/linkfinder.py
@@ -52,7 +52,7 @@ regex_str = r"""
 
     ([a-zA-Z0-9_\-]{1,}                 # filename
     \.(?:php|asp|aspx|jsp|json|
-         action|js|txt|xml)             # . + extension
+         action|html|js|txt|xml)             # . + extension
     (?:\?[^"|']{0,}|))                  # ? mark with parameters
 
   )

--- a/linkfinder.py
+++ b/linkfinder.py
@@ -44,13 +44,14 @@ regex_str = r"""
     |
 
     ([a-zA-Z0-9_\-/]{1,}/               # Relative endpoint with /
-    [a-zA-Z0-9_\-/]{1,}\.[a-zA-Z]{1,4}  # Rest + extension
+    [a-zA-Z0-9_\-/]{1,}                 # Resource name
+    \.(?:[a-zA-Z]{1,4}|action)          # Rest + extension (length 1-4 or action)
     (?:[\?|/][^"|']{0,}|))              # ? mark with parameters
 
     |
 
     ([a-zA-Z0-9_\-]{1,}                 # filename
-    \.(?:php|asp|aspx|jsp|json)         # . + extension
+    \.(?:php|asp|aspx|jsp|json|action)  # . + extension
     (?:\?[^"|']{0,}|))                  # ? mark with parameters
 
   )

--- a/linkfinder.py
+++ b/linkfinder.py
@@ -51,7 +51,8 @@ regex_str = r"""
     |
 
     ([a-zA-Z0-9_\-]{1,}                 # filename
-    \.(?:php|asp|aspx|jsp|json|action)  # . + extension
+    \.(?:php|asp|aspx|jsp|json|
+         action|js|txt|xml)             # . + extension
     (?:\?[^"|']{0,}|))                  # ? mark with parameters
 
   )

--- a/test_parser.py
+++ b/test_parser.py
@@ -20,12 +20,15 @@ def test_parser_cli():
     assert get_parse_cli("\"/path/to/file\"") == ["/path/to/file"]
     assert get_parse_cli("\"../path/to/file\"") == ["../path/to/file"]
     assert get_parse_cli("\"./path/to/file\"") == ["./path/to/file"]
+    assert get_parse_cli("\"/user/create.action?user=Test\"") == ["/user/create.action?user=Test"]
+    assert get_parse_cli("\"/api/create.php?user=test&pass=test#home\"") == ["/api/create.php?user=test&pass=test#home"]
     assert get_parse_cli("\"/wrong/file/test<>b\"") == []
 
-    assert get_parse_cli("\"/api/create.php\"") == ["/api/create.php"]
-    assert get_parse_cli("\"/api/create.php?user=test\"") == ["/api/create.php?user=test"]
-    assert get_parse_cli("\"/api/create.php?user=test&pass=test\"") == ["/api/create.php?user=test&pass=test"]
-    assert get_parse_cli("\"/api/create.php?user=test#home\"") == ["/api/create.php?user=test#home"]
+    assert get_parse_cli("\"api/create.php\"") == ["api/create.php"]
+    assert get_parse_cli("\"api/create.php?user=test\"") == ["api/create.php?user=test"]
+    assert get_parse_cli("\"api/create.php?user=test&pass=test\"") == ["api/create.php?user=test&pass=test"]
+    assert get_parse_cli("\"api/create.php?user=test#home\"") == ["api/create.php?user=test#home"]
+    assert get_parse_cli("\"user/create.action?user=Test\"") == ["user/create.action?user=Test"]
 
     assert get_parse_cli("\"/path/to/file\"") == ["/path/to/file"]
     assert get_parse_cli("\"../path/to/file\"") == ["../path/to/file"]
@@ -34,6 +37,7 @@ def test_parser_cli():
 
     assert get_parse_cli("\"test_1.json\"") == ["test_1.json"]
     assert get_parse_cli("\"test2.aspx?arg1=tmp1+tmp2&arg2=tmp3\"") == ["test2.aspx?arg1=tmp1+tmp2&arg2=tmp3"]
+    assert get_parse_cli("\"addUser.action\"") == ["addUser.action"]
 
 def test_parser_cli_multi():
     assert set(get_parse_cli("href=\"http://example.com\";href=\"/api/create.php\"")) == set(["http://example.com", "/api/create.php"])

--- a/test_parser.py
+++ b/test_parser.py
@@ -29,6 +29,7 @@ def test_parser_cli():
     assert get_parse_cli("\"api/create.php?user=test&pass=test\"") == ["api/create.php?user=test&pass=test"]
     assert get_parse_cli("\"api/create.php?user=test#home\"") == ["api/create.php?user=test#home"]
     assert get_parse_cli("\"user/create.action?user=Test\"") == ["user/create.action?user=Test"]
+    assert get_parse_cli("\"user/create.notaext?user=Test\"") == []
 
     assert get_parse_cli("\"/path/to/file\"") == ["/path/to/file"]
     assert get_parse_cli("\"../path/to/file\"") == ["../path/to/file"]
@@ -38,6 +39,10 @@ def test_parser_cli():
     assert get_parse_cli("\"test_1.json\"") == ["test_1.json"]
     assert get_parse_cli("\"test2.aspx?arg1=tmp1+tmp2&arg2=tmp3\"") == ["test2.aspx?arg1=tmp1+tmp2&arg2=tmp3"]
     assert get_parse_cli("\"addUser.action\"") == ["addUser.action"]
+    assert get_parse_cli("\"main.js\"") == ["main.js"]
+    assert get_parse_cli("\"robots.txt\"") == ["robots.txt"]
+    assert get_parse_cli("\"users.xml\"") == ["users.xml"]
+    assert get_parse_cli("\"UserModel.name\"") == []
 
 def test_parser_cli_multi():
     assert set(get_parse_cli("href=\"http://example.com\";href=\"/api/create.php\"")) == set(["http://example.com", "/api/create.php"])

--- a/test_parser.py
+++ b/test_parser.py
@@ -40,6 +40,7 @@ def test_parser_cli():
     assert get_parse_cli("\"test2.aspx?arg1=tmp1+tmp2&arg2=tmp3\"") == ["test2.aspx?arg1=tmp1+tmp2&arg2=tmp3"]
     assert get_parse_cli("\"addUser.action\"") == ["addUser.action"]
     assert get_parse_cli("\"main.js\"") == ["main.js"]
+    assert get_parse_cli("\"index.html\"") == ["index.html"]
     assert get_parse_cli("\"robots.txt\"") == ["robots.txt"]
     assert get_parse_cli("\"users.xml\"") == ["users.xml"]
     assert get_parse_cli("\"UserModel.name\"") == []


### PR DESCRIPTION
# Type
Enhancement

# Issue
- I have seen several apache struts projects with .action extension. I noticed that some part of regex did not cover that extention so the linkFinder might miss them.

# Solution
- Added .action into the regex.
- Also added more extension (.js, .xml, .txt, .html) into the regex too. The reason is that most xml/txt are informative.
- Added .html too since
-- most parts of regex already detect that
-- html extension like `window.location="secret.html"` could be useful
- Added more test case

# Further question
- From the README
```LinkFinder is a python script written to discover endpoints and their parameters in JavaScript files. ```
However, with "-d" argument that will follow and search any javascript path found. Since javascript is rarely found or embed in another javascript (I might have missed something here, feel free to inform me) so I think this project is no longer specific to searching the JavaScript file but also html/etc ? More specifically, I'm confused with "-d" argument scope.