### PR TITLE
Remove argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(
     long_description=open('README.md').read(),
     author='Gerben Javado',
     url='https://github.com/GerbenJavado/LinkFinder',
-    install_requires=['argparse', 'jsbeautifier'],
+    install_requires=['jsbeautifier'],
 )


### PR DESCRIPTION
`argparse` is a standard Python module.