### PR TITLE
Add no_browser (-nB) switch to disable auto-opening of HTML output

### DIFF
--- a/linkfinder.py
+++ b/linkfinder.py
@@ -256,10 +256,11 @@ def html_save(html):
 
         print("URL to access output: file://%s" % os.path.abspath(args.output))
         file = "file:///%s" % os.path.abspath(args.output)
-        if sys.platform == 'linux' or sys.platform == 'linux2':
-            subprocess.call(["xdg-open", file])
-        else:
-            webbrowser.open(file)
+        if not args.no_browser:
+            if sys.platform == 'linux' or sys.platform == 'linux2':
+                subprocess.call(["xdg-open", file])
+            else:
+                webbrowser.open(file)
     except Exception as e:
         print("Output can't be saved in %s \
             due to exception: %s" % (args.output, e))
@@ -312,6 +313,9 @@ if __name__ == "__main__":
     parser.add_argument("-t", "--timeout",
                         help="How many seconds to wait for the server to send data before giving up (default: " + str(default_timeout) + " seconds)",
                         default=default_timeout, type=int, metavar="<seconds>")
+    parser.add_argument("-nB", "--no_browser",
+                        help="Do not auto-open browser to render HTML output.",
+                        action="store_true")
     args = parser.parse_args()
 
     if args.input[-1:] == "/":


### PR DESCRIPTION
Addition of a `--no_browser`/`--nB` switch to address issue #80 (_"Add an argument to not open the browser if the output is set to html"_).