### PR TITLE
Change sslcontext to solve a DeprecationWarning

### DIFF
--- a/linkfinder.py
+++ b/linkfinder.py
@@ -130,7 +130,7 @@ def send_request(url):
     q.add_header('Cookie', args.cookies)
 
     try:
-        sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         response = urlopen(q, timeout=args.timeout, context=sslcontext)
     except:
         sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)


### PR DESCRIPTION
Just update sslcontext since previous value raised the following warning: DeprecationWarning: ssl.PROTOCOL_TLSv1_2 is deprecated