### PR TITLE
Improve regex to gather links even it has more than one dot

### DIFF
--- a/linkfinder.py
+++ b/linkfinder.py
@@ -44,7 +44,7 @@ regex_str = r"""
     |
 
     ([a-zA-Z0-9_\-/]{1,}/               # Relative endpoint with /
-    [a-zA-Z0-9_\-/]{1,}                 # Resource name
+    [a-zA-Z0-9_\-/.]{1,}                # Resource name
     \.(?:[a-zA-Z]{1,4}|action)          # Rest + extension (length 1-4 or action)
     (?:[\?|#][^"|']{0,}|))              # ? or # mark with parameters
 

--- a/test_parser.py
+++ b/test_parser.py
@@ -51,6 +51,9 @@ def test_parser_cli():
     assert get_parse_cli("\"users.xml\"") == ["users.xml"]
     assert get_parse_cli("\"UserModel.name\"") == []
 
+    assert get_parse_cli("\"app/admin/admin.controller.js\"") == ["app/admin/admin.controller.js"]
+    assert get_parse_cli("\"services/customer.services.js\"") == ["services/customer.services.js"]
+
 def test_parser_cli_multi():
     assert set(get_parse_cli("href=\"http://example.com\";href=\"/api/create.php\"")) == set(["http://example.com", "/api/create.php"])
 


### PR DESCRIPTION
Gather links even it has more than one dot

For example - 
`/app/admin/admin.controller.js`
`/services/customer.services.js`
