### PR TITLE
Skip directories while scanning file system

### DIFF
--- a/linkfinder.py
+++ b/linkfinder.py
@@ -104,9 +104,10 @@ def parser_input(input):
     # Method 4 - Folder with a wildcard
     if "*" in input:
         paths = glob.glob(os.path.abspath(input))
-        for index, path in enumerate(paths):
-            paths[index] = "file://%s" % path
-        return (paths if len(paths) > 0 else parser_error('Input with wildcard does \
+        file_paths = [p for p in paths if os.path.isfile(p)]
+        for index, path in enumerate(file_paths):
+            file_paths[index] = "file://%s" % path
+        return (file_paths if len(file_paths) > 0 else parser_error('Input with wildcard does \
         not match any files.'))
 
     # Method 5 - Local file


### PR DESCRIPTION
Fixes `Error: invalid input defined or SSL error: <urlopen error [Errno 21] Is a directory: ...`

When calling `linkfinder` like this: `./linkfinder.py -i './*'`