### PR TITLE
Added CLI entry point and updated install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,32 @@ The output is given in HTML or plaintext. [@karel_origin](https://twitter.com/ka
 
 ## Installation
 
-LinkFinder supports **Python 3**.
+LinkFinder supports **Python 3** and can now be installed like any other CLI tool.
 
+### Option 1: Install via `pip` (user-only)
+
+```bash
+pip install --user git+https://github.com/GerbenJavado/LinkFinder.git
 ```
-$ git clone https://github.com/GerbenJavado/LinkFinder.git
-$ cd LinkFinder
-$ python setup.py install
+
+This installs the `linkfinder` command to `~/.local/bin`. Make sure that directory is in your `PATH`.
+
+### Option 2: Install via `pipx` (recommended for CLI tools)
+
+```bash
+pipx install git+https://github.com/GerbenJavado/LinkFinder.git
 ```
+
+This creates an isolated environment and installs the `linkfinder` command to `~/.local/bin`. Make sure that directory is in your `PATH`.
 
 ## Dependencies
 
-LinkFinder depends on the `argparse` and `jsbeautifier` Python modules. These dependencies can all be installed using [pip](https://pypi.python.org/pypi/pip).
+All dependencies are now managed via `pip`. They will be installed automatically when using `pip install .` or `pipx install`.
 
-```
-$ pip3 install -r requirements.txt
+Alternatively, you can install them manually with:
+
+```bash
+pip install -r requirements.txt
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -61,23 +61,23 @@ Short Form    | Long Form     | Description
 
 * Most basic usage to find endpoints in an online JavaScript file and output the HTML results to results.html:
 
-`python linkfinder.py -i https://example.com/1.js -o results.html`
+`linkfinder -i https://example.com/1.js -o results.html`
 
 * CLI/STDOUT output (doesn't use jsbeautifier, which makes it very fast):
 
-`python linkfinder.py -i https://example.com/1.js -o cli`
+`linkfinder -i https://example.com/1.js -o cli`
 
 * Analyzing an entire domain and its JS files:
 
-`python linkfinder.py -i https://example.com -d`
+`linkfinder -i https://example.com -d`
 
 * Burp input (select in target the files you want to save, right click, `Save selected items`, feed that file as input):
 
-`python linkfinder.py -i burpfile -b`
+`linkfinder -i burpfile -b`
 
 * Enumerating an entire folder for JavaScript files, while looking for endpoints starting with /api/ and finally saving the results to results.html:
 
-`python linkfinder.py -i 'Desktop/*.js' -r ^/api/ -o results.html`
+`linkfinder -i 'Desktop/*.js' -r ^/api/ -o results.html`
 
 ## Docker
 

--- a/linkfinder.py
+++ b/linkfinder.py
@@ -131,10 +131,10 @@ def send_request(url):
     q.add_header('Cookie', args.cookies)
 
     try:
-        sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        sslcontext = ssl.create_default_context()
         response = urlopen(q, timeout=args.timeout, context=sslcontext)
     except:
-        sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        sslcontext = ssl.create_default_context()
         response = urlopen(q, timeout=args.timeout, context=sslcontext)
 
     if response.info().get('Content-Encoding') == 'gzip':
@@ -285,7 +285,7 @@ def check_url(url):
     else:
         return False
 
-if __name__ == "__main__":
+def main():
     # Parse command line
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--domain",
@@ -401,3 +401,6 @@ if __name__ == "__main__":
 
     if args.output != 'cli':
         html_save(output)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,9 @@ setup(
     url='https://github.com/GerbenJavado/LinkFinder',
     py_modules=['linkfinder'],
     install_requires=['jsbeautifier'],
+    entry_points={
+        'console_scripts': [
+            'linkfinder = linkfinder:main',
+        ],
+    },
 )


### PR DESCRIPTION
To ease up the installation and running of the tool, I added a `console_script` entrypoint in `setup.py`, so that the tool can be executed directly with `linkfinder` after installation instead of `python3 linkfinder.py`.

Also updated the installation instructions for how to install without having to clone the repo (and also added pipx instructions).