### PR TITLE
Handle backtick quoted urls + Regex improvements

### DIFF
--- a/linkfinder.py
+++ b/linkfinder.py
@@ -32,8 +32,8 @@ regex_str = r"""
 
   (
     ((?:[a-zA-Z]{1,10}://|//)           # Match a scheme [a-Z]*1-10 or //
-    [^"'/]{1,}\.                        # Match a domainname (any character + dot)
-    [a-zA-Z]{2,}[^"']{0,})              # The domainextension and/or path
+    [^"'`/]{1,}\.                        # Match a domainname (any character + dot)
+    [a-zA-Z]{2,}[^"'`]{0,})              # The domainextension and/or path
 
     |
 

--- a/linkfinder.py
+++ b/linkfinder.py
@@ -28,7 +28,7 @@ except ImportError:
 # Regex used
 regex_str = r"""
 
-  (?:"|')                               # Start newline delimiter
+  (?:["'`])                               # Start newline delimiter
 
   (
     ((?:[a-zA-Z]{1,10}://|//)           # Match a scheme [a-Z]*1-10 or //
@@ -38,32 +38,33 @@ regex_str = r"""
     |
 
     ((?:/|\.\./|\./)                    # Start with /,../,./
-    [^"'><,;| *()(%%$^/\\\[\]]          # Next character can't be...
-    [^"'><,;|()]{1,})                   # Rest of the characters can't be
+    [^"'`><,;| *()(%%$^/\\\[\]]          # Next character can't be...
+    [^"'`><,;|()]{1,}                   # Rest of the characters can't be
+    (?:[?#][^"'`]{0,})?)                 #Consider ?,# in url
 
     |
 
     ([a-zA-Z0-9_\-/]{1,}/               # Relative endpoint with /
     [a-zA-Z0-9_\-/.]{1,}                # Resource name
     \.(?:[a-zA-Z]{1,4}|action)          # Rest + extension (length 1-4 or action)
-    (?:[\?|#][^"|']{0,}|))              # ? or # mark with parameters
+    (?:[?#][^"'`]{0,})?)              # ? or # mark with parameters
 
     |
 
     ([a-zA-Z0-9_\-/]{1,}/               # REST API (no extension) with /
     [a-zA-Z0-9_\-/]{3,}                 # Proper REST endpoints usually have 3+ chars
-    (?:[\?|#][^"|']{0,}|))              # ? or # mark with parameters
+    (?:[\?|#][^"'`]{0,})?)              # ? or # mark with parameters
 
     |
 
     ([a-zA-Z0-9_\-]{1,}                 # filename
     \.(?:php|asp|aspx|jsp|json|
          action|html|js|txt|xml)        # . + extension
-    (?:[\?|#][^"|']{0,}|))              # ? or # mark with parameters
+    (?:[\?|#][^"'`]{0,})?)              # ? or # mark with parameters
 
   )
 
-  (?:"|')                               # End newline delimiter
+  (?:["'`])                               # End newline delimiter
 
 """
 

--- a/test_parser.py
+++ b/test_parser.py
@@ -54,6 +54,17 @@ def test_parser_cli():
     assert get_parse_cli("\"app/admin/admin.controller.js\"") == ["app/admin/admin.controller.js"]
     assert get_parse_cli("\"services/customer.services.js\"") == ["services/customer.services.js"]
 
+    # Tests for single-quote (') quoted urls
+    assert get_parse_cli("'test2.aspx?arg1=tmp1+tmp2&arg2=tmp3'") == ["test2.aspx?arg1=tmp1+tmp2&arg2=tmp3"]
+    assert get_parse_cli("'/test-faq?locale=${t}&populate=deep,10'") == ["/test-faq?locale=${t}&populate=deep,10"]
+    assert get_parse_cli("'/popups?locale=${e}&sort=id:desc&filters[type][$eq]=${t}&populate=deep,10'") == ["/popups?locale=${e}&sort=id:desc&filters[type][$eq]=${t}&populate=deep,10"]
+
+    # Tests for backtick (`) quoted urls
+    assert get_parse_cli("`/test-faq?locale=${t}&populate=deep,10`") == ["/test-faq?locale=${t}&populate=deep,10"]
+    assert get_parse_cli("`/test-faq/?locale=${t}`") == ["/test-faq/?locale=${t}"]
+    assert get_parse_cli("`/test-faq#$-1234-@`") == ["/test-faq#$-1234-@"]
+    assert get_parse_cli("`/popups?locale=${e}&sort=id:desc&filters[type][$eq]=${t}&populate=deep,10`") == ["/popups?locale=${e}&sort=id:desc&filters[type][$eq]=${t}&populate=deep,10"]
+
 def test_parser_cli_multi():
     assert set(get_parse_cli("href=\"http://example.com\";href=\"/api/create.php\"")) == set(["http://example.com", "/api/create.php"])
 


### PR DESCRIPTION
Handle backtick quoted urls
Use ? in regex for 0 or 1 match instead of (\<pattern\>|) syntax